### PR TITLE
chore: use lts/* Node.js version in all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'lts/*'
 
       - name: Run JS script to generate contents.json
         run: node scripts/generateContents.js
@@ -45,7 +45,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'lts/*'
 
       - name: Cypress run
         uses: cypress-io/github-action@v6

--- a/.github/workflows/test-viewer.yml
+++ b/.github/workflows/test-viewer.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'lts/*'
 
       - name: Run JS script to generate contents.json
         run: node scripts/generateContents.js
@@ -46,7 +46,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'lts/*'
 
       - name: Cypress run
         uses: cypress-io/github-action@v6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: 'lts/*'
 
     - name: Install ajv-cli
       run: npm install -g ajv-cli


### PR DESCRIPTION
## Summary
- Replace hardcoded Node.js versions (`16`, `20`) with `lts/*` in `ci.yml`, `test-viewer.yml`, and `validate.yml`
- `lts/*` always resolves to the current active LTS release (Node 22 today) and advances automatically when the next LTS is released

Nodejs 16 is end of life since 2023, Nodejs 20 is eol since March.